### PR TITLE
updates to annual report

### DIFF
--- a/hilights.org
+++ b/hilights.org
@@ -1,6 +1,6 @@
 * New Member Projects
 
-Three new projects joined Conservancy in 2013, phpMyAdmin, Buildbot
+Three new projects joined Conservancy in FY2013:  phpMyAdmin, Buildbot
 and OpenTripPlanner.
 
 phpMyAdmin provides a Free and Open Source web interface for several
@@ -50,15 +50,7 @@ developer hackfest, several interest group meetings, and two tracks of
 programs, one aimed at end users and another aimed at technical users
 and developers.
 
-* Releases
-
-The Evergreen project announced two major releases - 2.4 and 2.5 -
-during fiscal year2013. These new releases featured a responsive
-design for Evergreen’s public catalog, the ability for users to
-self-register for a library account, and many workflow improvements
-and new features for library staff using Evergreen.
-
-* Hack-a-way
+* Evergreen Hack-a-way
 
 The Evergreen project held a developer hack-a-way in Grand Rapids,
 Michigan in September 2013. During the hack-a-way, developers made big

--- a/project-hilights.org
+++ b/project-hilights.org
@@ -34,7 +34,7 @@ Darcs is an Open Source, cross platform version control system that
 focuses on changes, rather than snapshots, which allows for a freer
 and more streamlined approach to version control.
 
-In 2013, the Darcs team announced the Darcsden project, an Open Source
+In FY2013, the Darcs team announced the Darcsden project, an Open Source
 repository hosting platform for Darcs, written in Haskell. It
 currently offers several features like authentication from
 Github/OpenID, password recovery, online repository file editing, and
@@ -61,15 +61,15 @@ improvements to the visual elements of the software.
 * phpMyAdmin
 
 phpMyAdmin is a web interface to several popular database systems
-including mySQL, MariaDB and Drizzle. In 2013, Conservancy welcomed
-phpMyAdmin to its list of sponsored projects. They also released a new
-version of their software which included a significant improvement to
+including mySQL, MariaDB and Drizzle. In FY2013, Conservancy welcomed
+phpMyAdmin to its list of sponsored projects. phpMyAdmin also released a 
+new version of their software which included a significant improvement to
 their web interface.
 
 * Squeak
 
 Squeak is a full featured programming environment based on the
-Smalltalk programming language. In 2013 Scratch made a number of
+Smalltalk programming language. In FY2013 Scratch made a number of
 improvements to its design to allow it to run more easily on low
 powered devices such as the Raspberry Pi, OPLC or PIC
 microcontrollers. By focusing on small, low powered devices, Scratch
@@ -84,7 +84,7 @@ especially for children, Sugar's estimated three million users
 worldwide are offered an alternative to traditional “office-desktop”
 software.
 
-In 2013, Sugar Labs made strides in making JavaScript/HTML5 a first
+In FY2013, Sugar Labs made strides in making JavaScript/HTML5 a first
 class programming environment while continuing to work closely with
 the Fedora and GNOME upstream communities. Over 30% of the patches in
 their newest release come directly from Sugar users: the children
@@ -95,7 +95,7 @@ themselves.
 SWIG is a software development tool that connects programs written in
 low level languages like C and C++ with a variety of high-level
 programming languages such as as Javascript, Perl, PHP, Python, Tcl
-and Ruby. In 2013 the SWIG team released version 3.0.0, which included
+and Ruby. In FY2013 the SWIG team released version 3.0.0, which included
 better C++ support, support for the new C++11 standard as well as
 nested classes.
 

--- a/project-hilights.org
+++ b/project-hilights.org
@@ -40,11 +40,19 @@ currently offers several features like authentication from
 Github/OpenID, password recovery, online repository file editing, and
 comparisons between a repository and its forks.
 
+* Evergreen
+
+The Evergreen project announced two major releases - 2.4 and 2.5 -
+during FY2013. These new releases featured a responsive
+design for Evergreen’s public catalog, the ability for users to
+self-register for a library account, and many workflow improvements
+and new features for library staff using Evergreen.
+
 * Inkscape
 
 Inkscape is an Open Source vector graphics editor similar to Adobe
 Illustrator or Corel Draw. What sets Inkscape apart is its use of
-Scalable Vector Graphics (SVG) as its native format. In 2013 Inkscape
+Scalable Vector Graphics (SVG) as its native format. In FY2013, Inkscape
 made significant improvements to the security, stability and
 functionality of its software including improvements to its CAD
 support, document template support, vectorizing pixelized images and


### PR DESCRIPTION
Hi, all. 
I think we should use "FY2013" instead of '2013" to emphasize that this report covers the fiscal year, not the calendar year.  

I also see that we need some content describing C++ Now 2014 (cppnow.org), Boost's conference, as well as SeConf 2014, a confernece hosted by Agile FAQs and co-organized by Selenium volunteers.  I'll work on some content. 
